### PR TITLE
Moved the imgIndex prop up to Overview, setIndex to 0 when setStyle

### DIFF
--- a/client/src/components/Overview/ExpandedView.jsx
+++ b/client/src/components/Overview/ExpandedView.jsx
@@ -1,0 +1,20 @@
+import React, { useState, useEffect } from 'react';
+
+import { makeStyles } from '@material-ui/core/styles';
+import { Grid, Typography, Paper, Container } from '@material-ui/core';
+
+const useStyles = makeStyles({});
+
+const ExpandedView = React.forwardRef((props, ref) => {
+
+  return (
+    <Grid container>
+      <Typography>
+        Hey There!
+      </Typography>
+    </Grid>
+  )
+
+});
+
+export default ExpandedView

--- a/client/src/components/Overview/ImageGallery.jsx
+++ b/client/src/components/Overview/ImageGallery.jsx
@@ -31,9 +31,8 @@ const useStyles = makeStyles({
   }
 })
 
-const ImageGallery = ({ photos }) => {
+const ImageGallery = ({ photos, imgIndex, setImgIndex }) => {
   const classes = useStyles();
-  const [imgIndex, setImgIndex] = useState(0);
 
   const grabSevenThumbs = () => {
     let start = 0;

--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -34,6 +34,7 @@ const Overview = ({ productId }) => {
   const classes = useStyles();
   const [productDetails, setProductDetails] = useState(null)
   const [styleIndex, setStyleIndex] = useState(0);
+  const [imgIndex, setImgIndex] = useState(0);
 
   useEffect(() => {
     let currentProductDetails = {};
@@ -96,14 +97,19 @@ const Overview = ({ productId }) => {
         alignItems="flex-start"
       >
         <Grid item xs={7}>
-          <ImageGallery photos={productDetails.productStyles[styleIndex].photos}/>
+          <ImageGallery
+          photos={productDetails.productStyles[styleIndex].photos}
+          imgIndex={imgIndex}
+          setImgIndex={setImgIndex}/>
         </Grid>
         <Grid item xs={5}>
           <ProductDetails
             currentProduct={productDetails.productInfo}
             productStyles={productDetails.productStyles}
             styleIndex={styleIndex}
-            changeStyle={setStyleIndex}
+            imgIndex={imgIndex}
+            setStyleIndex={setStyleIndex}
+            setImgIndex={setImgIndex}
           />
         </Grid>
         {showDetails()}

--- a/client/src/components/Overview/ProductDetails.jsx
+++ b/client/src/components/Overview/ProductDetails.jsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles({
   }
 })
 
-const ProductDetails = ({currentProduct, productStyles, styleIndex, changeStyle}) => {
+const ProductDetails = ({currentProduct, productStyles, styleIndex, imgIndex, setStyleIndex, setImgIndex}) => {
   const classes = useStyles();
   const [stock, setStock] = useState([]);
   const [skuIndex, setSkuIndex] = useState('');
@@ -118,7 +118,7 @@ const ProductDetails = ({currentProduct, productStyles, styleIndex, changeStyle}
       return null
     } else {
       return (
-        <Select labelId="size" id="selectSize" value={skuIndex} displayEmpty={true}variant="outlined" fullWidth onChange={sizeChange}>
+        <Select labelId="size" id="selectSize" value={skuIndex} displayEmpty={true} variant="outlined" fullWidth onChange={sizeChange}>
           <MenuItem value=''>Select Size</MenuItem>
           {stock.map(({ size }, skuIndex) => {
             return <MenuItem value={skuIndex} key={skuIndex}>{size}</MenuItem>
@@ -207,7 +207,13 @@ const ProductDetails = ({currentProduct, productStyles, styleIndex, changeStyle}
       <Grid container className={classes.price}>
         {displayPrice()}
       </Grid>
-       <StyleSelector productStyles={productStyles} styleIndex={styleIndex} changeStyle={changeStyle} />
+       <StyleSelector
+        productStyles={productStyles}
+        styleIndex={styleIndex}
+        imgIndex={imgIndex}
+        setStyleIndex={setStyleIndex}
+        setImgIndex={setImgIndex}
+      />
       <Grid container spacing={1}>
         <Grid item xs={8}>
           {sizeSelection()}

--- a/client/src/components/Overview/StyleSelector.jsx
+++ b/client/src/components/Overview/StyleSelector.jsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles({
   }
 });
 
-const StyleSelector = ({ productStyles, styleIndex, changeStyle }) => {
+const StyleSelector = ({ productStyles, styleIndex, imgIndex, setStyleIndex, setImgIndex }) => {
   const classes = useStyles();
 
   return (
@@ -59,7 +59,8 @@ const StyleSelector = ({ productStyles, styleIndex, changeStyle }) => {
                 elevation={3}
                 style={styleBG}
                 onClick={() => {
-                  changeStyle(index)
+                  setStyleIndex(index);
+                  setImgIndex(0);
                 }}/>
             </Grid>
           )


### PR DESCRIPTION
Tested it on product 38329 , I confirmed the the imgIndex is set to 0 when a style changes. 

This may result in a tech debt ticket because of the requirement to maintain the index when the style changes...
<img width="538" alt="Project Catwalk - Business Requirements Document - Google Docs 2021-09-17 11-43-56" src="https://user-images.githubusercontent.com/23545273/133824638-b85c1710-ccca-4218-b8a4-0f2ce0b429e1.png">

Since this could result a breaking scenario, maybe we'll just indicate that the nuance could not be delivered.